### PR TITLE
Fix: Same List except by index mais performático

### DIFF
--- a/array/same-list-except-by-index.go
+++ b/array/same-list-except-by-index.go
@@ -1,12 +1,11 @@
 package array
 
 func SameListExcept[T any](list []T, indexToNotInclude int) []T {
-	var newList []T
-	for index, value := range list {
-		if index == indexToNotInclude {
-			continue
-		}
-		newList = append(newList, value)
-	}
+	newList := make([]T, 0, len(list)-1)
+
+	newList = append(newList, list[:indexToNotInclude]...)
+
+	newList = append(newList, list[indexToNotInclude+1:]...)
+
 	return newList
 }

--- a/path/has-parent-path.go
+++ b/path/has-parent-path.go
@@ -21,16 +21,32 @@ func isUNCBase(path string) bool {
 func (p Path) HasParentPath() bool {
 	clean := filepath.Clean(p.Path)
 
-	if runtime.GOOS == "windows" {
-		clean = strings.ReplaceAll(clean, "/", `\`)
-		if isWindowsRoot(clean) || isUNCBase(clean) {
-			return false
-		}
-	} else {
-		if clean == "/" {
-			return false
-		}
+	isRoot := handleRunTimeOnParentPathAndReturnIfItsRoot(&clean)
+
+	if isRoot {
+		return false
 	}
 
 	return filepath.Dir(clean) != clean
+}
+
+func handleRunTimeOnParentPathAndReturnIfItsRoot(clean *string) bool {
+	if runtime.GOOS == "windows" {
+		return handleWindowsAndReturnIfItsRoot(clean)
+	}
+
+	return handleLinuxAndReturnIfItsRott(clean)
+}
+
+func handleWindowsAndReturnIfItsRoot(clean *string) bool {
+	*clean = strings.ReplaceAll(*clean, "/", `\`)
+	if isWindowsRoot(*clean) || isUNCBase(*clean) {
+		return true
+	}
+
+	return false
+}
+
+func handleLinuxAndReturnIfItsRott(clean *string) bool {
+	return *clean == "/"
 }


### PR DESCRIPTION
antes na função SameListExcept do pacote array era feito um for completo por toda a lista de elementos, para remover um item. Agora é apenas feito um append simples.
Além disso a função HasParentPath do pacote array, está mais bem escrito, com separação das responsabilidades.